### PR TITLE
Added addHeader-Method

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -323,6 +323,7 @@ modal.close();
     });
 
     modalTinyBtn.setContent(document.querySelector('.tingle-demo-tiny').innerHTML);
+    modalTinyBtn.addHeader('The Header');
 
     modalTinyBtn.addFooterBtn('Primary action', 'tingle-btn tingle-btn--primary tingle-btn--pull-right', function() {
         alert('click on primary button!');

--- a/doc/tingle/tingle.css
+++ b/doc/tingle/tingle.css
@@ -201,6 +201,25 @@
   float: right;
 }
 
+/*Header*/
+.tingle-head{
+    padding: 1.5rem 1rem;
+    font-weight: bold;
+    position: absolute;
+    top: 0;
+    background: #eaeaea;
+    width: 100%;
+    border-radius: 4px 4px 0 0;
+    height: 54px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tingle-box-w-header{
+    padding-top: 54px;
+}
+
 /* responsive
 -------------------------------------------------------------- */
 

--- a/doc/tingle/tingle.js
+++ b/doc/tingle/tingle.js
@@ -222,6 +222,21 @@
         return btn;
     };
 
+    Modal.prototype.addHeader = function(label) {
+        var head = document.createElement("div");
+        head.classList.add('tingle-head');
+
+        // set label
+        head.innerHTML = label;
+
+        //The head should not overlay the content
+        this.modalBox.classList.add('tingle-box-w-header');
+
+        this.modalBox.appendChild(head);
+
+        return head;
+    };
+
     Modal.prototype.resize = function() {
         console.warn('Resize is deprecated and will be removed in version 1.0');
     };

--- a/src/tingle.css
+++ b/src/tingle.css
@@ -179,6 +179,25 @@
   float: right;
 }
 
+/*Header*/
+.tingle-head{
+    padding: 1.5rem 1rem;
+    font-weight: bold;
+    position: absolute;
+    top: 0;
+    background: #eaeaea;
+    width: 100%;
+    border-radius: 4px 4px 0 0;
+    height: 54px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tingle-box-w-header{
+    padding-top: 54px;
+}
+
 /* responsive
 -------------------------------------------------------------- */
 

--- a/src/tingle.js
+++ b/src/tingle.js
@@ -222,6 +222,21 @@
         return btn;
     };
 
+    Modal.prototype.addHeader = function(label) {
+        var head = document.createElement("div");
+        head.classList.add('tingle-head');
+
+        // set label
+        head.innerHTML = label;
+
+        //The head should not overlay the content
+        this.modalBox.classList.add('tingle-box-w-header');
+
+        this.modalBox.appendChild(head);
+
+        return head;
+    };
+
     Modal.prototype.resize = function() {
         console.warn('Resize is deprecated and will be removed in version 1.0');
     };


### PR DESCRIPTION
Added a method to add a header to the modal, you can see an example on /doc/index.html on the 
second button ("Need Buttons?").
![tigle-header](https://cloud.githubusercontent.com/assets/13721712/23343863/b6806ee4-fc72-11e6-9786-631e2f5a4b1e.png)

Usage is pretty easy:
```js
 modal.addHeader('The Header');
```

As i'm not very good at javascript, the code's probably a mess - pardon that.