### PR TITLE
made checkoverflow public

### DIFF
--- a/src/tingle.js
+++ b/src/tingle.js
@@ -20,7 +20,6 @@
 
     var transitionEvent = whichTransitionEvent();
 
-
     function Modal(options) {
 
         var defaults = {
@@ -109,8 +108,7 @@
         }
 
         // check if modal is bigger than screen height
-        _checkOverflow.call(this);
-
+        this.checkOverflow();
     };
 
     Modal.prototype.isOpen = function() {
@@ -244,13 +242,7 @@
         return modalHeight >= viewportHeight;
     };
 
-
-    /* ----------------------------------------------------------- */
-    /* == private methods */
-    /* ----------------------------------------------------------- */
-
-
-    function _checkOverflow() {
+    Modal.prototype.checkOverflow = function() {
         // only if the modal is currently shown
         if (this.modal.classList.contains('tingle-modal--visible')) {
             if (this.isOverflow()) {
@@ -269,6 +261,11 @@
             }
         }
     }
+
+
+    /* ----------------------------------------------------------- */
+    /* == private methods */
+    /* ----------------------------------------------------------- */
 
     function _recalculateFooterPosition() {
         if (!this.modalBoxFooter) {
@@ -344,7 +341,7 @@
         this._events = {
             clickCloseBtn: this.close.bind(this),
             clickOverlay: _handleClickOutside.bind(this),
-            resize: _checkOverflow.bind(this),
+            resize: this.checkOverflow.bind(this),
             keyboardNav: _handleKeyboardNav.bind(this)
         };
 


### PR DESCRIPTION
I have a use case where data inside the modal is asynchronously loaded from a backend service. I have no way of knowing ahead of time how large the content is going to be, and whether it will or will not overflow. Therefore, the single call to `_checkOverflow()` when the modal is opened is not enough, as I need to open the modal immediately to show a loading animation, then load the content in as it is downloaded. All I've done in this PR is make `checkOverflow` public, so that it may be called at any time (in my case, after my promises resolve).