### PR TITLE
iOS header/overflow fix

### DIFF
--- a/src/tingle.css
+++ b/src/tingle.css
@@ -184,23 +184,28 @@
 -------------------------------------------------------------- */
 
 @media (max-width : 540px) {
+  .tingle-modal {
+    top: 0px;
+    display: block;
+    width: 100%;
+    padding-top: 60px;
+  }
+
   .tingle-modal-box {
     width: auto;
     border-radius: 0;
   }
 
-  .tingle-modal {
-    top: 60px;
-    display: block;
-    width: 100%;
+  .tingle-modal-box__content {
+    overflow-y: scroll;
   }
 
   .tingle-modal--noClose {
     top: 0;
   }
 
-  .tingle-modal--overflow {
-    padding: 0;
+  .tingle-modal--noOverlayClose {
+    padding-top: 0;
   }
 
   .tingle-modal-box__footer .tingle-btn {


### PR DESCRIPTION
This is intended to fix #42 as well as provide a partial fix for #36. With regards to #36, the content in the modal now scrolls, but if you reach the bottom, it begins scrolling the content of the page in the background. I was not able to find a good solution to this, but it's an improvement. #42 is fixed entirely.
Here are some screenshots from iPhone 6/iOS 8 (real device): [0](https://cloud.githubusercontent.com/assets/20479454/25829309/e52ba044-341a-11e7-90c9-cddcd4715999.jpg) [1](https://cloud.githubusercontent.com/assets/20479454/25829298/ddc01100-341a-11e7-8689-99e931f61280.jpg) [2](https://cloud.githubusercontent.com/assets/20479454/25829302/df9fe70c-341a-11e7-964c-abb87371d9b9.jpg) [3](https://cloud.githubusercontent.com/assets/20479454/25829304/e1938514-341a-11e7-87ba-917110184aab.jpg) [4](https://cloud.githubusercontent.com/assets/20479454/25829306/e30ed402-341a-11e7-8c93-b22fbfcd7883.jpg)

You can check out/test these changes on another device at https://shurelia.github.io/tingle/


