### PR TITLE
Fixed iOS background scrolling

### DIFF
--- a/src/tingle.css
+++ b/src/tingle.css
@@ -22,6 +22,7 @@
   opacity: 0;
   cursor: pointer;
   transition: transform .2s ease;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* confirm and alerts
@@ -114,6 +115,7 @@
 -------------------------------------------------------------- */
 
 .tingle-enabled {
+  position: fixed;
   overflow: hidden;
   height: 100%;
 }

--- a/src/tingle.js
+++ b/src/tingle.js
@@ -88,7 +88,9 @@
         }
 
         // prevent double scroll
+        this.scrollPosition = window.pageYOffset;
         document.body.classList.add('tingle-enabled');
+        document.body.style.top = -this.scrollPosition + 'px';
 
         // sticky footer
         this.setStickyFooter(this.opts.stickyFooter);
@@ -129,6 +131,7 @@
         }
 
         document.body.classList.remove('tingle-enabled');
+        window.scrollTo(0, this.scrollPosition);
 
         this.modal.classList.remove('tingle-modal--visible');
 

--- a/src/tingle.js
+++ b/src/tingle.js
@@ -88,9 +88,9 @@
         }
 
         // prevent double scroll
-        this.scrollPosition = window.pageYOffset;
+        this._scrollPosition = window.pageYOffset;
         document.body.classList.add('tingle-enabled');
-        document.body.style.top = -this.scrollPosition + 'px';
+        document.body.style.top = -this._scrollPosition + 'px';
 
         // sticky footer
         this.setStickyFooter(this.opts.stickyFooter);
@@ -131,7 +131,7 @@
         }
 
         document.body.classList.remove('tingle-enabled');
-        window.scrollTo(0, this.scrollPosition);
+        window.scrollTo(0, this._scrollPosition);
 
         this.modal.classList.remove('tingle-modal--visible');
 


### PR DESCRIPTION
Fixes #36.
`position: fixed;` on the body div is what prevents any background scrolling. However, setting this on its own causes the main content to scroll all the way to the top. To prevent this we store the scroll position, apply `position: fixed` to the body, and set the `top` of the body to that scroll position (so the background remains consistent while the modal is open). Then, when body's `fixed` is unset, we scrollTo that saved position.

`-webkit-overflow-scrolling: touch;` provides momentum scrolling on iOS devices. In the gif below, it looks a little choppy due to framerate, but it looks much more fluid and native-like on a native device. However, there is a small amount of 'jitter' on the close button and sticky footer area (most noticeable when using both) when scrolling on ios. This can be eliminated by setting `-webkit-overflow-scrolling: auto;`, but provides a very poor scrolling experience (no momentum on scroll, so the user has to repeatedly swipe down to scroll down). I believe that a fix for that behavior would require a more extensive overhaul of the library. For the moment I think that `touch` provides the best user experience.

Here are videos of the bug:
---------------without overflow-------------------------------with overflow------------------
![bug-no-overflow](https://user-images.githubusercontent.com/20479454/31587472-f6388216-b1a7-11e7-8a88-edd5c38ae6e9.gif) ![bug-overflow](https://user-images.githubusercontent.com/20479454/31587473-f652f60a-b1a7-11e7-849e-1ee4ab117359.gif)

Here are videos of what the behavior looks like with this patch:
---------------without overflow-------------------------------with overflow------------------
![fix-no-overflow](https://user-images.githubusercontent.com/20479454/31587499-51ff094e-b1a8-11e7-9b13-8690695947b1.gif) ![fix-overflow](https://user-images.githubusercontent.com/20479454/31587498-51f3e898-b1a8-11e7-8403-3782d8cf6eb8.gif)


