### PR TITLE
Automatic background blur

### DIFF
--- a/src/tingle.css
+++ b/src/tingle.css
@@ -244,16 +244,14 @@
   }
 }
 
-@supports ((-webkit-backdrop-filter: blur(12px)) or (backdrop-filter: blur(12px))) {
+@supports (backdrop-filter: blur(12px)) {
   .tingle-modal {
     backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
   }
 
   @media (max-width : 540px) {
     .tingle-modal {
       backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
     }
   }
 

--- a/src/tingle.css
+++ b/src/tingle.css
@@ -123,7 +123,7 @@
 }
 
 .tingle-enabled .tingle-content-wrapper {
-  filter: blur(15px);
+  filter: blur(12px);
 }
 
 .tingle-modal--visible {
@@ -241,5 +241,23 @@
     margin-right: .5rem;
     vertical-align: middle;
     font-size: 4rem;
+  }
+}
+
+@supports ((-webkit-backdrop-filter: blur(12px)) or (backdrop-filter: blur(12px))) {
+  .tingle-modal {
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+
+  @media (max-width : 540px) {
+    .tingle-modal {
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+    }
+  }
+
+  .tingle-enabled .tingle-content-wrapper {
+    filter: none;
   }
 }


### PR DESCRIPTION
 The blur feature of tingle is really nice, but requires the `tingle-content-wrapper` class to be set on an element in the implementing site. This may not be an option in some instances. This PR automatically applies the background blur (with no changes necessary in the implementing site) on browsers that support `backdrop-filter` (currently just safari). The current behavior is otherwise retained.

Here's what it looks like:
iOS: [screenshot](https://user-images.githubusercontent.com/20479454/31588805-c4a7f19a-b1bc-11e7-9111-3bbf7a51364c.jpg)
Mac: [screenshot](https://user-images.githubusercontent.com/20479454/31588807-d1247ae2-b1bc-11e7-9a1f-de1e46579166.png)

