### PR TITLE
Allow back button to close modal

### DIFF
--- a/src/tingle.css
+++ b/src/tingle.css
@@ -22,6 +22,7 @@
   opacity: 0;
   cursor: pointer;
   transition: transform .2s ease;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* confirm and alerts
@@ -114,6 +115,7 @@
 -------------------------------------------------------------- */
 
 .tingle-enabled {
+  position: fixed;
   overflow: hidden;
   height: 100%;
 }

--- a/src/tingle.css
+++ b/src/tingle.css
@@ -246,16 +246,14 @@
   }
 }
 
-@supports ((-webkit-backdrop-filter: blur(12px)) or (backdrop-filter: blur(12px))) {
+@supports (backdrop-filter: blur(12px)) {
   .tingle-modal {
     backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
   }
 
   @media (max-width : 540px) {
     .tingle-modal {
       backdrop-filter: blur(8px);
-      -webkit-backdrop-filter: blur(8px);
     }
   }
 

--- a/src/tingle.css
+++ b/src/tingle.css
@@ -125,7 +125,7 @@
 }
 
 .tingle-enabled .tingle-content-wrapper {
-  filter: blur(15px);
+  filter: blur(12px);
 }
 
 .tingle-modal--visible {
@@ -243,5 +243,23 @@
     margin-right: .5rem;
     vertical-align: middle;
     font-size: 4rem;
+  }
+}
+
+@supports ((-webkit-backdrop-filter: blur(12px)) or (backdrop-filter: blur(12px))) {
+  .tingle-modal {
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+
+  @media (max-width : 540px) {
+    .tingle-modal {
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+    }
+  }
+
+  .tingle-enabled .tingle-content-wrapper {
+    filter: none;
   }
 }

--- a/src/tingle.js
+++ b/src/tingle.js
@@ -88,7 +88,9 @@
         }
 
         // prevent double scroll
+        this.scrollPosition = window.pageYOffset;
         document.body.classList.add('tingle-enabled');
+        document.body.style.top = -this.scrollPosition + 'px';
 
         // sticky footer
         this.setStickyFooter(this.opts.stickyFooter);
@@ -129,6 +131,7 @@
         }
 
         document.body.classList.remove('tingle-enabled');
+        window.scrollTo(0, this.scrollPosition);
 
         this.modal.classList.remove('tingle-modal--visible');
 

--- a/src/tingle.js
+++ b/src/tingle.js
@@ -297,16 +297,19 @@
                 if (typeof self.opts.onClose === "function") {
                     self.opts.onClose.call(this);
                 }
+
+                // Unset the active modal
+                Modal.prototype.active = null;
             }, false);
         } else {
             // on close callback
             if (typeof self.opts.onClose === "function") {
                 self.opts.onClose.call(this);
             }
-        }
 
-        // Unset the active modal
-        Modal.prototype.active = null;
+            // Unset the active modal
+            Modal.prototype.active = null;
+        }
     }
 
     function _build() {

--- a/src/tingle.js
+++ b/src/tingle.js
@@ -105,9 +105,9 @@
         }
 
         // prevent double scroll
-        this.scrollPosition = window.pageYOffset;
+        this._scrollPosition = window.pageYOffset;
         document.body.classList.add('tingle-enabled');
-        document.body.style.top = -this.scrollPosition + 'px';
+        document.body.style.top = -this._scrollPosition + 'px';
 
         // sticky footer
         this.setStickyFooter(this.opts.stickyFooter);
@@ -279,7 +279,7 @@
         }
 
         document.body.classList.remove('tingle-enabled');
-        window.scrollTo(0, this.scrollPosition);
+        window.scrollTo(0, this._scrollPosition);
 
         this.modal.classList.remove('tingle-modal--visible');
 

--- a/src/tingle.js
+++ b/src/tingle.js
@@ -78,9 +78,7 @@
 
 
     Modal.prototype.open = function() {
-        console.log('open called on:', this._id);
         if (Modal.prototype.active !== null) {
-          console.log('cant open...')
           setTimeout(this.open.bind(this), 250);
           return;
         }
@@ -274,7 +272,6 @@
     }
 
     function _close() {
-        console.log('close called on: ', this._id);
         //  before close
         if (typeof this.opts.beforeClose === "function") {
             var close = this.opts.beforeClose.call(this);


### PR DESCRIPTION
**DO NOT MERGE. WORK IN PROGRESS.**
This fixes #48 and should fix #57 as well. This branch refactors a portion of the library and depends on the changes made in #68 and #69, so this should not be merged until those are reviewed.

This PR introduces a new option `history` (default true, for now) that creates history events when opening modals, and closes the modal in response to them. When the modal opens, it modifies the current history state to include a unique identifier for that particular modal, then pushes a new history state. The modal closes when a history popstate event is received containing that unique id (which will happen when back is pressed). All of the logic in `close()` has been broken off into a private method `_close()`, and `_close()` is called when the browser back button is pressed. Calling `close()` directly cause the back button press to be simulated.

Here's a video of this in action: [video demo](https://user-images.githubusercontent.com/20479454/31695032-84d42eaa-b36d-11e7-85f2-e3978401c12a.gif)

This has the following ramifications for the library:
* Multiple modals cannot be open at once. This causes side effects in the browser history. This doesn't seem like something that should be done anyways, as opening multiple modals layers them on top of each other and doesn't look great. The developer should close a modal before opening another. In this PR, this is enforced by checking if another modal is open before opening. If one is, it tries again in 250ms (due to the async nature of browser events, calling `close()` on one modal then `open()` on another will cause the new modal to try and open before the first one is closed). I'm not certain about this behavior, however, so it's something I want to get feedback on. Should we automatically try to handle this situation for the developer, or perhaps just throw an error for the developer to handle their selves? The latter seems more reliable, but decreases the usability of the library.
* Developer cannot call `close()` on a modal that is not open. This doesn't seem like something the developer should be doing anyways. Again, this causes unwanted side effects in the browser history. In this PR, an `isOpen()` check is done before `close()` runs.