### PR TITLE
Fix #116

### DIFF
--- a/src/tingle.js
+++ b/src/tingle.js
@@ -151,7 +151,10 @@
         //  before close
         if (typeof this.opts.beforeClose === 'function') {
             var close = this.opts.beforeClose.call(this)
-            if (!close) return
+            if (!close) {
+                this._busy(false)
+                return
+            }
         }
 
         document.body.classList.remove('tingle-enabled')


### PR DESCRIPTION
When returning false onBeforeClose, the modal is stuck in busy state and can never be closed.
Setting is busy to false before returning.