### PR TITLE
feat(src): add support for closeIcon without closeLabel

### DIFF
--- a/src/tingle.css
+++ b/src/tingle.css
@@ -231,11 +231,11 @@
     vertical-align: middle;
     font-size: 1.6rem;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    margin-left: .8rem;
   }
 
   .tingle-modal__closeIcon {
     display: inline-block;
-    margin-right: .8rem;
     width: 1.6rem;
     vertical-align: middle;
     font-size: 0;

--- a/src/tingle.js
+++ b/src/tingle.js
@@ -327,12 +327,16 @@
       this.modalCloseBtnIcon.classList.add('tingle-modal__closeIcon')
       this.modalCloseBtnIcon.innerHTML = closeIcon()
 
-      this.modalCloseBtnLabel = document.createElement('span')
-      this.modalCloseBtnLabel.classList.add('tingle-modal__closeLabel')
-      this.modalCloseBtnLabel.innerHTML = this.opts.closeLabel
-
       this.modalCloseBtn.appendChild(this.modalCloseBtnIcon)
-      this.modalCloseBtn.appendChild(this.modalCloseBtnLabel)
+      
+      if (this.opts.closeLabel !== '') {
+        this.modalCloseBtnLabel = document.createElement('span')
+        this.modalCloseBtnLabel.classList.add('tingle-modal__closeLabel')
+        this.modalCloseBtnLabel.innerHTML = this.opts.closeLabel
+        
+        this.modalCloseBtn.appendChild(this.modalCloseBtnLabel)
+      }
+
     }
 
     // modal


### PR DESCRIPTION
Make "closeLabel" display optional.
Just set:
`        const modalTinyNoFooter = new tingle.modal({
            closeLabel: "",
        });`
Result:
![Screen Shot 2021-04-24 at 16 21 10](https://user-images.githubusercontent.com/42910420/115960368-abcc7200-a519-11eb-8ba3-c33bf9d5a5fd.png)